### PR TITLE
Add option to begin with all the maps and filler items for when there are unfilled locations

### DIFF
--- a/Haiku.Rando/Bitset64.cs
+++ b/Haiku.Rando/Bitset64.cs
@@ -1,0 +1,30 @@
+namespace Haiku.Rando
+{
+    internal struct Bitset64
+    {
+        private ulong _bits;
+
+        public Bitset64(ulong b)
+        {
+            _bits = b;
+        }
+
+        private ulong Mask(int i)
+        {
+            if (!(i >= 0 && i < 64))
+            {
+                throw new System.ArgumentOutOfRangeException($"index {i} out of range [0,64[");
+            }
+            return 1UL << i;
+        }
+
+        public bool Contains(int i) => (_bits & Mask(i)) != 0;
+
+        public void Add(int i)
+        {
+            _bits |= Mask(i);
+        }
+
+        public ulong Bits => _bits;
+    }
+}

--- a/Haiku.Rando/Checks/CheckManager.cs
+++ b/Haiku.Rando/Checks/CheckManager.cs
@@ -44,7 +44,6 @@ namespace Haiku.Rando.Checks
             On.BeeHive.TriggerBulbItem += BeeHive_TriggerBulbItem;
             On.e29Portal.GiveRewardsGradually += E29Portal_GiveRewardsGradually;
             On.e29PortalRewardChecker.CheckReward += E29PortalRewardChecker_CheckReward;
-            On.ReplenishHealth.CheckChipsWhenGameStarts += ReplenishHealth_CheckChipsWhenGameStarts;
 
             IL.MotherWindUp.Start += MotherWindUp_Start;
             IL.MotherWindUp.EndDialogueAction += MotherWindUp_EndDialogueAction;
@@ -433,16 +432,6 @@ namespace Haiku.Rando.Checks
             else
             {
                 //Not a mapped check; fall back to standard behavior
-                orig(self);
-            }
-        }
-
-        private void ReplenishHealth_CheckChipsWhenGameStarts(On.ReplenishHealth.orig_CheckChipsWhenGameStarts orig, ReplenishHealth self)
-        {
-            //The chips check only runs when not using randomization
-            //Otherwise it will grant chips for world locations that shouldn't have been set
-            if (Instance.Randomizer == null)
-            {
                 orig(self);
             }
         }

--- a/Haiku.Rando/Checks/ShopItemReplacer.cs
+++ b/Haiku.Rando/Checks/ShopItemReplacer.cs
@@ -161,6 +161,10 @@ namespace Haiku.Rando.Checks
                 case CheckType.Clock:
                     //This is never randomized, but is important to logic
                     break;
+                case CheckType.Filler:
+                    title = Text._NOTHING_TITLE;
+                    description = Text._NOTHING_DESCRIPTION;
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -278,6 +282,8 @@ namespace Haiku.Rando.Checks
                     break;
                 case CheckType.Clock:
                     //This is never randomized, but is important to logic
+                    break;
+                case CheckType.Filler:
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Haiku.Rando/Logic/CheckRandomizer.cs
+++ b/Haiku.Rando/Logic/CheckRandomizer.cs
@@ -430,6 +430,10 @@ namespace Haiku.Rando.Logic
             {
                 _pool.RemoveAll(c => c.Type == CheckType.Item && c.CheckId == (int)ItemId.Whistle);
             }
+            if (Settings.StartWithMaps.Value)
+            {
+                _pool.RemoveAll(c => c.Type == CheckType.MapDisruptor);
+            }
         }
 
         private void AddToPool(CheckType checkType)

--- a/Haiku.Rando/RandoPlugin.cs
+++ b/Haiku.Rando/RandoPlugin.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Linq;
-using SysDiag = System.Diagnostics;
 using BepInEx;
 using Haiku.Rando.Checks;
 using Haiku.Rando.Logic;
@@ -46,7 +45,6 @@ namespace Haiku.Rando
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
 
             // prevent CheckChipsWhenGameStarts from giving unexpected chips
-            // (only a partial solution; the real cause of the bug is deeper)
             On.ReplenishHealth.CheckChipsWhenGameStarts += WarnCheckChips;
 
             //TODO: Add bosses as logic conditions
@@ -56,11 +54,6 @@ namespace Haiku.Rando
         private void WarnCheckChips(On.ReplenishHealth.orig_CheckChipsWhenGameStarts orig, ReplenishHealth self)
         {
             if (_randomizer == null) orig(self);
-            if (!GameManager.instance.corruptMode)
-            {
-                Logger.LogInfo("CheckChipsWhenGameStarts invoked");
-                Logger.LogInfo(new SysDiag.StackTrace(1).ToString());
-            }
         }
 
         private void ReloadTopology()
@@ -183,6 +176,26 @@ namespace Haiku.Rando
             if (Settings.StartWithWhistle.Value && !CheckManager.HasItem(ItemId.Whistle))
             {
                 InventoryManager.instance.AddItem((int)ItemId.Whistle);
+            }
+
+            if (Settings.StartWithMaps.Value)
+            {
+                // The following is directly copied from DebugMod's GiveAllMaps.
+                for (int i = 0; i < GameManager.instance.mapTiles.Length; i++)
+                {
+                    GameManager.instance.mapTiles[i].explored = true;
+                }
+                for (int j = 0; j < GameManager.instance.disruptors.Length; j++)
+                {
+                    GameManager.instance.disruptors[j].destroyed = true;
+                }
+
+                //Turn on all map markers
+                GameManager.instance.showPowercells = true;
+                GameManager.instance.showHealthStations = true;
+                GameManager.instance.showBankStations = true;
+                GameManager.instance.showVendors = true;
+                GameManager.instance.showTrainStations = true;
             }
 
             if (!success)

--- a/Haiku.Rando/SaveData.cs
+++ b/Haiku.Rando/SaveData.cs
@@ -7,9 +7,11 @@ namespace Haiku.Rando
         private const string presenceKey = "hasRandoData";
         private const string seedKey = "randoSeed";
         private const string collectedLoreKey = "randoCollectedLoreTablets";
+        private const string collectedFillerKey = "randoCollectedFillers";
 
         public ulong Seed;
-        public ulong CollectedLore;
+        public Bitset64 CollectedLore;
+        public Bitset64 CollectedFillers;
 
         public static SaveData Load(ES3File saveFile) =>
             saveFile.Load<bool>(presenceKey, false) ? new(saveFile) : null;
@@ -21,30 +23,17 @@ namespace Haiku.Rando
         private SaveData(ES3File saveFile)
         {
             Seed = saveFile.Load<ulong>(seedKey, 0UL);
-            CollectedLore = saveFile.Load<ulong>("randoCollectedLoreTablets", 0UL);
+            CollectedLore = new(saveFile.Load<ulong>(collectedLoreKey, 0UL));
+            CollectedFillers = new(saveFile.Load<ulong>(collectedFillerKey, 0UL));
         }
 
         public void SaveTo(ES3File saveFile)
         {
             saveFile.Save(presenceKey, true);
             saveFile.Save(seedKey, Seed);
-            saveFile.Save(collectedLoreKey, CollectedLore);
+            saveFile.Save(collectedLoreKey, CollectedLore.Bits);
+            saveFile.Save(collectedFillerKey, CollectedFillers.Bits);
             saveFile.Sync();
-        }
-
-        private static ulong LoreMask(int i)
-        {
-            if (!(i >= 0 && i < 64))
-            {
-                throw new System.IndexOutOfRangeException($"index {i} for lore is out of range [0,64[");
-            }
-            return 1UL << i;
-        }
-
-        public bool IsLoreCollected(int i) => (CollectedLore & LoreMask(i)) != 0;
-        public void MarkLoreCollected(int i)
-        {
-            CollectedLore |= LoreMask(i);
         }
     }
 }

--- a/Haiku.Rando/Settings.cs
+++ b/Haiku.Rando/Settings.cs
@@ -13,6 +13,7 @@ namespace Haiku.Rando
         public static ConfigEntry<bool> RandomStartLocation { get; private set; }
         public static ConfigEntry<bool> StartWithWrench { get; private set; }
         public static ConfigEntry<bool> StartWithWhistle { get; private set; }
+        public static ConfigEntry<bool> StartWithMaps { get; private set; }
 
         public static ConfigEntry<bool> IncludeWrench { get; private set; }
         public static ConfigEntry<bool> IncludeBulblet { get; private set; }
@@ -43,6 +44,7 @@ namespace Haiku.Rando
             RandomStartLocation = config.Bind(General, "Random Start Location", false);
             StartWithWrench = config.Bind(General, "Start With Wrench", false);
             StartWithWhistle = config.Bind(General, "Start with Whistle", false);
+            StartWithMaps = config.Bind(General, "Start with Maps", false);
             //TODO: Load/Save settings to copyable string
             //TODO: Hash display for race sync
             //ConfigManagerUtil.createButton(config, ShowHash, General, "ShowHash", "Show Hash");

--- a/Haiku.Rando/Text.cs
+++ b/Haiku.Rando/Text.cs
@@ -4,12 +4,16 @@ namespace Haiku.Rando
     {
         public static string _LORE_TITLE => "_LORE_TITLE";
         public static string _LORE_DESCRIPTION => "_LORE_DESCRIPTION";
+        public static string _NOTHING_TITLE => "_NOTHING_TITLE";
+        public static string _NOTHING_DESCRIPTION => "_NOTHING_DESCRIPTION";
 
         private static void Load(On.LocalizationSystem.orig_Init orig)
         {
             orig();
             LocalizationSystem.localizedEN[_LORE_TITLE] = "Lore";
             LocalizationSystem.localizedEN[_LORE_DESCRIPTION] = "The digitised wisdom of past Arcadians.";
+            LocalizationSystem.localizedEN[_NOTHING_TITLE] = "Nothing";
+            LocalizationSystem.localizedEN[_NOTHING_DESCRIPTION] = "This page intentionally left blank.";
         }
 
         internal static void Hook()

--- a/Haiku.Rando/Topology/CheckType.cs
+++ b/Haiku.Rando/Topology/CheckType.cs
@@ -22,6 +22,7 @@ namespace Haiku.Rando.Topology
         FireRes,
         WaterRes,
         TrainStation,
-        Clock
+        Clock,
+        Filler
     }
 }


### PR DESCRIPTION
The option is primarily intended for use with the map mod, so that the map disruptor locations can remain in the pool even if their items are not. This will result in some locations not having an item; those will now be filled with Nothing items.