### PR TITLE
Store generation settings in the save file

### DIFF
--- a/Haiku.Rando/GenerationSettings.cs
+++ b/Haiku.Rando/GenerationSettings.cs
@@ -1,0 +1,37 @@
+namespace Haiku.Rando
+{
+    public class GenerationSettings
+    {
+        public string Seed;
+        public bool RandomStartLocation;
+        internal Bitset64 Pools;
+        internal Bitset64 StartingItems;
+        public RandomizationLevel Level;
+
+        public bool Contains(Pool p) => Pools.Contains((int)p);
+        public bool Contains(StartingItemSet s) => StartingItems.Contains((int)s);
+    }
+
+    public enum Pool
+    {
+        Wrench,
+        Bulblet,
+        Abilities,
+        Items,
+        Chips,
+        ChipSlots,
+        MapDisruptors,
+        MapMarkers,
+        PowerCells,
+        Coolant,
+        Sealants,
+        Lore
+    }
+
+    public enum StartingItemSet
+    {
+        Wrench,
+        Whistle,
+        Maps
+    }
+}

--- a/Haiku.Rando/Logic/CheckRandomizer.cs
+++ b/Haiku.Rando/Logic/CheckRandomizer.cs
@@ -23,18 +23,18 @@ namespace Haiku.Rando.Logic
         private bool _randomized;
         private int _numFillersAdded;
 
-        public CheckRandomizer(RandoTopology topology, LogicEvaluator logic, ulong seed, int? startScene)
+        public CheckRandomizer(RandoTopology topology, LogicEvaluator logic, GenerationSettings gs, Seed128 seed, int? startScene)
         {
             _topology = topology;
             _logic = logic;
             _startScene = startScene;
 
-            Seed = seed;
-            _random = new Xoroshiro128Plus(seed);
+            Settings = gs;
+            _random = new Xoroshiro128Plus(seed.S0, seed.S1);
             _logic.Context = this;
         }
 
-        public ulong Seed { get; }
+        public GenerationSettings Settings { get; }
 
         public RandoTopology Topology => _topology;
 
@@ -404,35 +404,35 @@ namespace Haiku.Rando.Logic
         {
             _pool.Clear();
             _startingPool.Clear();
-            if (Settings.IncludeWrench.Value) AddToPool(CheckType.Wrench);
-            if (Settings.IncludeBulblet.Value) AddToPool(CheckType.Bulblet);
-            if (Settings.IncludeAbilities.Value) AddToPool(CheckType.Ability);
-            if (Settings.IncludeItems.Value) AddToPool(CheckType.Item);
-            if (Settings.IncludeChips.Value) AddToPool(CheckType.Chip);
-            if (Settings.IncludeChipSlots.Value) AddToPool(CheckType.ChipSlot);
-            if (Settings.IncludeMapDisruptors.Value) AddToPool(CheckType.MapDisruptor);
+            if (Settings.Contains(Pool.Wrench)) AddToPool(CheckType.Wrench);
+            if (Settings.Contains(Pool.Bulblet)) AddToPool(CheckType.Bulblet);
+            if (Settings.Contains(Pool.Abilities)) AddToPool(CheckType.Ability);
+            if (Settings.Contains(Pool.Items)) AddToPool(CheckType.Item);
+            if (Settings.Contains(Pool.Chips)) AddToPool(CheckType.Chip);
+            if (Settings.Contains(Pool.ChipSlots)) AddToPool(CheckType.ChipSlot);
+            if (Settings.Contains(Pool.MapDisruptors)) AddToPool(CheckType.MapDisruptor);
             //if (Settings.IncludeLevers.Value) AddToPool(CheckType.Lever);
-            if (Settings.IncludePowerCells.Value) AddToPool(CheckType.PowerCell);
-            if (Settings.IncludeCoolant.Value) AddToPool(CheckType.Coolant);
-            if (Settings.IncludeSealants.Value) AddToPool(CheckType.FireRes);
-            if (Settings.IncludeSealants.Value) AddToPool(CheckType.WaterRes);
-            if (Settings.IncludeLoreTablets.Value) AddToPool(CheckType.Lore);
-            if (Settings.IncludeMapMarkers.Value) AddToPool(CheckType.MapMarker);
+            if (Settings.Contains(Pool.PowerCells)) AddToPool(CheckType.PowerCell);
+            if (Settings.Contains(Pool.Coolant)) AddToPool(CheckType.Coolant);
+            if (Settings.Contains(Pool.Sealants)) AddToPool(CheckType.FireRes);
+            if (Settings.Contains(Pool.Sealants)) AddToPool(CheckType.WaterRes);
+            if (Settings.Contains(Pool.Lore)) AddToPool(CheckType.Lore);
+            if (Settings.Contains(Pool.MapMarkers)) AddToPool(CheckType.MapMarker);
 
             //Starting pool contains all the checks we're going to replace eventually
             _startingPool.AddRange(_pool);
 
             //We remove a few checks from the source pool based on special starting conditions
-            if (Settings.StartWithWrench.Value)
+            if (Settings.Contains(StartingItemSet.Wrench))
             {
                 _pool.RemoveAll(c => c.Type == CheckType.Wrench ||
                                     (c.Type == CheckType.Item && c.CheckId == (int)ItemId.Wrench));
             }
-            if (Settings.StartWithWhistle.Value)
+            if (Settings.Contains(StartingItemSet.Whistle))
             {
                 _pool.RemoveAll(c => c.Type == CheckType.Item && c.CheckId == (int)ItemId.Whistle);
             }
-            if (Settings.StartWithMaps.Value)
+            if (Settings.Contains(StartingItemSet.Maps))
             {
                 _pool.RemoveAll(c => c.Type == CheckType.MapDisruptor);
             }

--- a/Haiku.Rando/RandoPlugin.cs
+++ b/Haiku.Rando/RandoPlugin.cs
@@ -130,13 +130,14 @@ namespace Haiku.Rando
 
             // Add rando save data to the file if it does not already have it, and it's a
             // newly-started file (which introPlayed is a proxy for).
-            if (_saveData == null && !GameManager.instance.introPlayed)
+            if (_saveData == null && !GameManager.instance.introPlayed &&
+                Settings.GetGenerationSettings() is GenerationSettings s)
             {
-                var s = Settings.GetGenerationSettings();
-                if (s != null)
+                if (string.IsNullOrWhiteSpace(s.Seed))
                 {
-                    _saveData = new(s);
+                    s.Seed = DateTime.Now.Ticks.ToString();
                 }
+                _saveData = new(s);
             }
             var gs = _saveData?.Settings;
 

--- a/Haiku.Rando/RandoPlugin.cs
+++ b/Haiku.Rando/RandoPlugin.cs
@@ -128,20 +128,27 @@ namespace Haiku.Rando
             CheckManager.Instance.Randomizer = null;
             TransitionManager.Instance.Randomizer = null;
 
-            bool success = false;
-            var level = Settings.RandoLevel.Value;
-            if (level != RandomizationLevel.None)
+            // Add rando save data to the file if it does not already have it, and it's a
+            // newly-started file (which introPlayed is a proxy for).
+            if (_saveData == null && !GameManager.instance.introPlayed)
             {
-                if (_saveData == null)
+                var s = Settings.GetGenerationSettings();
+                if (s != null)
                 {
-                    _saveData = new(PickSeed());
+                    _saveData = new(s);
                 }
+            }
+            var gs = _saveData?.Settings;
 
+            bool success = false;
+            if (gs != null && gs.Level != RandomizationLevel.None)
+            {
                 int? startScene = SpecialScenes.GameStart;
                 const int maxRetries = 200;
+                var origSeed = gs.Seed;
                 for (int i = 0; i < maxRetries; i++)
                 {
-                    if (TryRandomize(level, out startScene))
+                    if (TryRandomize(gs, out startScene))
                     {
                         success = true;
                         break;
@@ -149,9 +156,8 @@ namespace Haiku.Rando
                     else
                     {
                         Debug.LogWarning($"Randomization failed: attempt {i+1} of {maxRetries}");
-
                         //Iterate the seed
-                        _saveData.Seed = new Xoroshiro128Plus(_saveData.Seed).NextULong();
+                        gs.Seed = $"{origSeed}__attempt{i+1}";
                     }
                 }
 
@@ -172,18 +178,18 @@ namespace Haiku.Rando
                 success = true;
             }
 
-            if (Settings.StartWithWrench.Value && !GameManager.instance.canHeal)
+            if (gs.Contains(StartingItemSet.Wrench) && !GameManager.instance.canHeal)
             {
                 GameManager.instance.canHeal = true;
                 InventoryManager.instance.AddItem((int)ItemId.Wrench);
             }
 
-            if (Settings.StartWithWhistle.Value && !CheckManager.HasItem(ItemId.Whistle))
+            if (gs.Contains(StartingItemSet.Whistle) && !CheckManager.HasItem(ItemId.Whistle))
             {
                 InventoryManager.instance.AddItem((int)ItemId.Whistle);
             }
 
-            if (Settings.StartWithMaps.Value)
+            if (gs.Contains(StartingItemSet.Maps))
             {
                 // The following is directly copied from DebugMod's GiveAllMaps.
                 for (int i = 0; i < GameManager.instance.mapTiles.Length; i++)
@@ -204,11 +210,15 @@ namespace Haiku.Rando
             }
         }
 
-        private bool TryRandomize(RandomizationLevel level, out int? startScene)
+        private bool TryRandomize(GenerationSettings gs, out int? startScene)
         {
+            // A previous room rando may have rewired the topology; make sure we start with the
+            // vanilla topology.
             ReloadTopology();
 
-            if (Settings.RandomStartLocation.Value)
+            var seed = new Seed128(gs.Seed);
+
+            if (gs.RandomStartLocation)
             {
                 //Pick from any save station except Incinerator, Furnace and Train
                 var availScenes = new List<int>
@@ -219,9 +229,7 @@ namespace Haiku.Rando
                 availScenes.Remove(156);
                 availScenes.Remove(127);
 
-                // Xoroshiro128Plus(UInt64) already mixes the seed bits, so further preprocessing
-                // is not required.
-                var tmpRandom = new Xoroshiro128Plus(_saveData.Seed);
+                var tmpRandom = new Xoroshiro128Plus(seed.S0, seed.S1);
                 startScene = availScenes[tmpRandom.NextRange(0, availScenes.Count)];
             }
             else
@@ -231,16 +239,16 @@ namespace Haiku.Rando
 
             var evaluator = new LogicEvaluator(new[] { _baseLogic });
 
-            if (level == RandomizationLevel.Rooms)
+            if (gs.Level == RandomizationLevel.Rooms)
             {
                 Debug.Log("** Configuring transition randomization **");
-                _transRandomizer = new TransitionRandomizer(_topology, evaluator, _saveData.Seed);
+                _transRandomizer = new TransitionRandomizer(_topology, evaluator, seed);
                 _transRandomizer.Randomize();
                 TransitionManager.Instance.Randomizer = _transRandomizer;
             }
 
             Debug.Log("** Configuring check randomization **");
-            _randomizer = new CheckRandomizer(_topology, evaluator, _saveData.Seed, startScene);
+            _randomizer = new CheckRandomizer(_topology, evaluator, gs, seed, startScene);
             bool success = _randomizer.Randomize();
 
             if (success)
@@ -252,20 +260,11 @@ namespace Haiku.Rando
             return success;
         }
 
-        private ulong PickSeed()
-        {
-            if (ulong.TryParse(Settings.Seed.Value ?? "", out var seed))
-            {
-                return seed;
-            }
-            return new Xoroshiro128Plus().NextULong();
-        }
-
         private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode mode)
         {
             CheckManager.Instance.OnSceneLoaded(scene.buildIndex);
 
-            if (Settings.RandoLevel.Value == RandomizationLevel.Rooms)
+            if (_saveData.Settings.Level == RandomizationLevel.Rooms)
             {
                 //In room rando, all rooms can disable fire
                 var detector = FindObjectOfType<FireResDetector>();

--- a/Haiku.Rando/SaveData.cs
+++ b/Haiku.Rando/SaveData.cs
@@ -6,23 +6,34 @@ namespace Haiku.Rando
     {
         private const string presenceKey = "hasRandoData";
         private const string seedKey = "randoSeed";
+        private const string randoStartKey = "randoRandomStart";
+        private const string poolsKey = "randoPools";
+        private const string startingItemsKey = "randoStartingItems";
+        private const string levelKey = "randoLevel";
         private const string collectedLoreKey = "randoCollectedLoreTablets";
         private const string collectedFillerKey = "randoCollectedFillers";
 
-        public ulong Seed;
+        public GenerationSettings Settings;
         public Bitset64 CollectedLore;
         public Bitset64 CollectedFillers;
 
         public static SaveData Load(ES3File saveFile) =>
             saveFile.Load<bool>(presenceKey, false) ? new(saveFile) : null;
 
-        public SaveData(ulong seed) {
-            Seed = seed;
+        public SaveData(GenerationSettings gs) {
+            Settings = gs;
         }
 
         private SaveData(ES3File saveFile)
         {
-            Seed = saveFile.Load<ulong>(seedKey, 0UL);
+            Settings = new()
+            {
+                Seed = saveFile.Load<string>(seedKey, ""),
+                RandomStartLocation = saveFile.Load<bool>(randoStartKey, false),
+                Pools = new(saveFile.Load<ulong>(poolsKey, 0UL)),
+                StartingItems = new(saveFile.Load<ulong>(startingItemsKey, 0UL)),
+                Level = (RandomizationLevel)saveFile.Load<int>(levelKey, 0)
+            };
             CollectedLore = new(saveFile.Load<ulong>(collectedLoreKey, 0UL));
             CollectedFillers = new(saveFile.Load<ulong>(collectedFillerKey, 0UL));
         }
@@ -30,7 +41,11 @@ namespace Haiku.Rando
         public void SaveTo(ES3File saveFile)
         {
             saveFile.Save(presenceKey, true);
-            saveFile.Save(seedKey, Seed);
+            saveFile.Save(seedKey, Settings.Seed);
+            saveFile.Save(randoStartKey, Settings.RandomStartLocation);
+            saveFile.Save(poolsKey, Settings.Pools.Bits);
+            saveFile.Save(startingItemsKey, Settings.StartingItems.Bits);
+            saveFile.Save(levelKey, (int)Settings.Level);
             saveFile.Save(collectedLoreKey, CollectedLore.Bits);
             saveFile.Save(collectedFillerKey, CollectedFillers.Bits);
             saveFile.Sync();

--- a/Haiku.Rando/Settings.cs
+++ b/Haiku.Rando/Settings.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using BepInEx.Configuration;
 using Modding;
 
@@ -11,23 +13,9 @@ namespace Haiku.Rando
         public static ConfigEntry<RandomizationLevel> RandoLevel { get; private set; }
         public static ConfigEntry<string> Seed { get; private set; }
         public static ConfigEntry<bool> RandomStartLocation { get; private set; }
-        public static ConfigEntry<bool> StartWithWrench { get; private set; }
-        public static ConfigEntry<bool> StartWithWhistle { get; private set; }
-        public static ConfigEntry<bool> StartWithMaps { get; private set; }
 
-        public static ConfigEntry<bool> IncludeWrench { get; private set; }
-        public static ConfigEntry<bool> IncludeBulblet { get; private set; }
-        public static ConfigEntry<bool> IncludeAbilities { get; private set; }
-        public static ConfigEntry<bool> IncludeItems { get; private set; }
-        public static ConfigEntry<bool> IncludeChips { get; private set; }
-        public static ConfigEntry<bool> IncludeChipSlots { get; private set; }
-        public static ConfigEntry<bool> IncludeMapDisruptors { get; private set; }
-        public static ConfigEntry<bool> IncludeMapMarkers { get; private set; }
-        //public static ConfigEntry<bool> IncludeLevers { get; private set; }
-        public static ConfigEntry<bool> IncludePowerCells { get; private set; }
-        public static ConfigEntry<bool> IncludeCoolant { get; private set; }
-        public static ConfigEntry<bool> IncludeSealants { get; private set; }
-        public static ConfigEntry<bool> IncludeLoreTablets { get; private set; }
+        private static List<ConfigEntry<bool>> StartingItemToggles;
+        private static List<ConfigEntry<bool>> PoolToggles;
 
         public static ConfigEntry<bool> FastMoney { get; private set; }
         public static ConfigEntry<bool> SyncedMoney { get; private set; }
@@ -35,34 +23,29 @@ namespace Haiku.Rando
 
         //Groups of settings
         private const string General = "General";
-        private const string Pool = "Pool";
         private const string QoL = "QoL";
+
+        private static readonly Regex camelCasePattern = new(@"([a-z])([A-Z])");
+
+        private static T[] EnumValues<T>() => (T[])Enum.GetValues(typeof(T));
+        private static string SplitCamelCase(string cc) => camelCasePattern.Replace(cc, "$1 $2");
 
         public static void Init(ConfigFile config)
         {
             RandoLevel = config.Bind(General, "Level", RandomizationLevel.Pickups);
             Seed = config.Bind(General, "Seed", "", "Seed (blank for auto)");
             RandomStartLocation = config.Bind(General, "Random Start Location", false);
-            StartWithWrench = config.Bind(General, "Start With Wrench", false);
-            StartWithWhistle = config.Bind(General, "Start with Whistle", false);
-            StartWithMaps = config.Bind(General, "Start with Maps", false);
+
+            StartingItemToggles = EnumValues<StartingItemSet>()
+                .Select(c => config.Bind("Starting Items", SplitCamelCase(c.ToString()), false))
+                .ToList();
+
+            PoolToggles = EnumValues<Pool>()
+                .Select(c => config.Bind("Pool", SplitCamelCase(c.ToString()), c != Pool.Wrench))
+                .ToList();
             //TODO: Load/Save settings to copyable string
             //TODO: Hash display for race sync
             //ConfigManagerUtil.createButton(config, ShowHash, General, "ShowHash", "Show Hash");
-
-            IncludeWrench = config.Bind(Pool, "Wrench", false);
-            IncludeBulblet = config.Bind(Pool, "Bulblet", true);
-            IncludeAbilities = config.Bind(Pool, "Abilities", true);
-            IncludeItems = config.Bind(Pool, "Items", true);
-            IncludeChips = config.Bind(Pool, "Chips", true);
-            IncludeChipSlots = config.Bind(Pool, "Chip Slots", true);
-            IncludeMapDisruptors = config.Bind(Pool, "Map Disruptors", true);
-            IncludeMapMarkers = config.Bind(Pool, "Map Markers", true);
-            //IncludeLevers = config.Bind(Pool, "Levers", false);
-            IncludePowerCells = config.Bind(Pool, "Power Cells", true);
-            IncludeCoolant = config.Bind(Pool, "Coolant", true);
-            IncludeSealants = config.Bind(Pool, "Sealants", true);
-            IncludeLoreTablets = config.Bind(Pool, "Lore Tablets", true);
 
             FastMoney = config.Bind(QoL, "FastMoney", true,
                                     "Makes it so that money totems drop all their money in a single hit");
@@ -73,6 +56,31 @@ namespace Haiku.Rando
 
             //Save defaults if didn't already exist
             config.Save();
+        }
+
+        public static GenerationSettings GetGenerationSettings()
+        {
+            if (RandoLevel.Value == RandomizationLevel.None)
+            {
+                return null;
+            }
+            
+            var gs = new GenerationSettings() { Seed = Seed.Value, Level = RandoLevel.Value, RandomStartLocation = RandomStartLocation.Value };
+            for (var i = 0; i < StartingItemToggles.Count; i++)
+            {
+                if (StartingItemToggles[i].Value)
+                {
+                    gs.StartingItems.Add(i);
+                }
+            }
+            for (var i = 0; i < PoolToggles.Count; i++)
+            {
+                if (PoolToggles[i].Value)
+                {
+                    gs.Pools.Add(i);
+                }
+            }
+            return gs;
         }
 
         private static void ShowHash()

--- a/Haiku.Rando/TransitionRandomizer.cs
+++ b/Haiku.Rando/TransitionRandomizer.cs
@@ -19,11 +19,11 @@ namespace Haiku.Rando
 
         public IReadOnlyDictionary<TransitionNode, TransitionNode> Swaps => _swaps;
 
-        public TransitionRandomizer(RandoTopology topology, LogicEvaluator logic, ulong seed)
+        public TransitionRandomizer(RandoTopology topology, LogicEvaluator logic, Seed128 seed)
         {
             _topology = topology;
             _logic = logic;
-            _random = new Xoroshiro128Plus(seed);
+            _random = new Xoroshiro128Plus(seed.S0, seed.S1);
         }
 
         public void Randomize()

--- a/Haiku.Rando/Util/Seed128.cs
+++ b/Haiku.Rando/Util/Seed128.cs
@@ -1,0 +1,24 @@
+using System.Text;
+using System.Security.Cryptography;
+
+namespace Haiku.Rando.Util
+{
+    public struct Seed128
+    {
+        public ulong S0;
+        public ulong S1;
+
+        public Seed128(string s)
+        {
+            var encoded = new UTF8Encoding().GetBytes(s);
+            using var sha = SHA256.Create();
+            var h = sha.ComputeHash(encoded);
+            S0 = h[0] | ((ulong)h[1] << 8) | ((ulong)h[2] << 16) | ((ulong)h[3] << 24) | 
+                ((ulong)h[4] << 32) | ((ulong)h[5] << 40) | ((ulong)h[6] << 48) |
+                ((ulong)h[7] << 56);
+            S1 = h[8] | ((ulong)h[9] << 8) | ((ulong)h[10] << 16) | ((ulong)h[11] << 24) |
+                ((ulong)h[12] << 32) | ((ulong)h[13] << 40) | ((ulong)h[14] << 48) |
+                ((ulong)h[15] << 56);
+        }
+    }
+}


### PR DESCRIPTION
No longer will your randomizer break if you change your settings and then load a previous file.

This also restores the ability to use arbitrary strings as the seed; they are fed to SHA256 and then the first 128 bits of the hash are used to seed the RNG.

Also, it enables other mods - like the map mod - to read the current save file's settings at any time.